### PR TITLE
fix: point GitHub badges at todoist-to-markdown repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,22 @@
 
 * lets release on pypi ([834adae](https://github.com/iloveitaly/todoist-to-markdown/commit/834adae6a27b0240cec91e3f92c87420345aa703))
 
-## [0.1.2](https://github.com/iloveitaly/todoist-to-md/compare/v0.1.1...v0.1.2) (2026-02-25)
+## [0.1.2](https://github.com/iloveitaly/todoist-to-markdown/compare/v0.1.1...v0.1.2) (2026-02-25)
 
 
 ### Documentation
 
-* clarify markdown sample for comments and metadata ([bd33e6b](https://github.com/iloveitaly/todoist-to-md/commit/bd33e6bc7437d918f48b43c81cd6c8df8bbad852))
+* clarify markdown sample for comments and metadata ([bd33e6b](https://github.com/iloveitaly/todoist-to-markdown/commit/bd33e6bc7437d918f48b43c81cd6c8df8bbad852))
 
 ## 0.1.1 (2025-06-25)
 
 
 ### Bug Fixes
 
-* improve markdown export format and add original URL ([be68b10](https://github.com/iloveitaly/todoist-to-md/commit/be68b1038cdee408e1401b129cb5e8e0a66984ee))
-* robust task ID parsing and todoist api key handling ([49b690d](https://github.com/iloveitaly/todoist-to-md/commit/49b690d3787c918cac9d538e4e261566edf904e4))
+* improve markdown export format and add original URL ([be68b10](https://github.com/iloveitaly/todoist-to-markdown/commit/be68b1038cdee408e1401b129cb5e8e0a66984ee))
+* robust task ID parsing and todoist api key handling ([49b690d](https://github.com/iloveitaly/todoist-to-markdown/commit/49b690d3787c918cac9d538e4e261566edf904e4))
 
 
 ### Reverts
 
-* Revert "refactor: simplify comment retrieval and format dependencies" ([302ee01](https://github.com/iloveitaly/todoist-to-md/commit/302ee01b63fed18984438154f6084d48b3bf7770))
+* Revert "refactor: simplify comment retrieval and format dependencies" ([302ee01](https://github.com/iloveitaly/todoist-to-markdown/commit/302ee01b63fed18984438154f6084d48b3bf7770))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Release Notes](https://img.shields.io/github/release/iloveitaly/todoist-to-md)](https://github.com/iloveitaly/todoist-to-md/releases)
+[![Release Notes](https://img.shields.io/github/release/iloveitaly/todoist-to-markdown)](https://github.com/iloveitaly/todoist-to-markdown/releases)
 [![Downloads](https://static.pepy.tech/badge/todoist-to-md/month)](https://pepy.tech/project/todoist-to-md)
-![GitHub CI Status](https://github.com/iloveitaly/todoist-to-md/actions/workflows/build_and_publish.yml/badge.svg)
+![GitHub CI Status](https://github.com/iloveitaly/todoist-to-markdown/actions/workflows/build_and_publish.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # Todoist Task to Markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = ["todoist-api-python", "click", "whenever"]
 authors = [{ name = "Michael Bianco", email = "mike@mikebian.co" }]
-urls = { "Repository" = "https://github.com/iloveitaly/todoist-to-md" }
+urls = { "Repository" = "https://github.com/iloveitaly/todoist-to-markdown" }
 
 # additional packaging information: https://packaging.python.org/en/latest/specifications/core-metadata/#license
 [project.scripts]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
GitHub badges (release + CI) and `pyproject.toml` `Repository` URL pointed at `iloveitaly/todoist-to-md`, which is the **PyPI** package name, not the GitHub repo (`iloveitaly/todoist-to-markdown`). That made the release badge show "no releases or repo not found" and the CI badge 404.

Also corrected the same wrong repo links in `CHANGELOG.md`.

Pepy downloads badge correctly uses `todoist-to-md` (PyPI) and is left as-is.

## Test plan
- [x] Confirm release shield resolves to `v0.1.3` for `todoist-to-markdown`
- [x] Confirm CI badge returns 200 / passing
- [x] Confirm `todoist-to-md` still 404s on GitHub
- [ ] Visual check on GitHub README after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24848ef7-3d19-436f-8400-d10b3cf9130a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24848ef7-3d19-436f-8400-d10b3cf9130a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

